### PR TITLE
Fix unexpected exception return behavior

### DIFF
--- a/04-Multitasking/context_switch.S
+++ b/04-Multitasking/context_switch.S
@@ -19,14 +19,21 @@ activate:
 	mrs ip, psr
 	push {r4, r5, r6, r7, r8, r9, r10, r11, ip, lr}
 
-	/* switch to process stack */
-	msr psp, r0
-	mov r0, #3
-	msr control, r0
-	isb
 
 	/* load user state */
-	pop {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+	ldmia r0!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
+
+	msr psp, r0
+
+	/* check the situaion and determine the transition */
+	mov r0, #0xfffffff0
+	cmp lr, r0                      @ lr - 0xfffffff0
+
+	/* if "lr" does not point to exception return, then switch to process stack */
+	ittt ls                         @ "ls" condition means unsinged lower or the same
+	movls r0, #3
+	msrls control, r0
+	isbls
 
 	/* jump to user task */
 	bx lr


### PR DESCRIPTION
Just like what I confuse in #14 
I write additional code to check the situation and omit unnecessary condition switching to unprivileged thread mode.