### PR TITLE
Fix unexpected intial content in user thread stack

### DIFF
--- a/07-Threads/threads.c
+++ b/07-Threads/threads.c
@@ -103,7 +103,7 @@ int thread_create(void (*run)(void *), void *userdata)
 		stack[9] = (unsigned int) userdata;
 		stack[14] = (unsigned) &thread_self_terminal;
 		stack[15] = (unsigned int) run;
-		stack[16] = (unsigned int) 0x21000000; /* PSR Thumb bit */
+		stack[16] = (unsigned int) 0x01000000; /* PSR Thumb bit */
 	}
 
 	/* Construct the control block */


### PR DESCRIPTION
When program initialize the second thread, we don't need to predefine apsr. It should be zero.