### PR TITLE
Fixed mode switch and stack size problem

### DIFF
--- a/04-Multitasking/context_switch.S
+++ b/04-Multitasking/context_switch.S
@@ -19,21 +19,9 @@ activate:
 	mrs ip, psr
 	push {r4, r5, r6, r7, r8, r9, r10, r11, ip, lr}
 
-
 	/* load user state */
 	ldmia r0!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
-
 	msr psp, r0
-
-	/* check the situaion and determine the transition */
-	mov r0, #0xfffffff0
-	cmp lr, r0                      @ lr - 0xfffffff0
-
-	/* if "lr" does not point to exception return, then switch to process stack */
-	ittt ls                         @ "ls" condition means unsinged lower or the same
-	movls r0, #3
-	msrls control, r0
-	isbls
 
 	/* jump to user task */
 	bx lr

--- a/04-Multitasking/os.c
+++ b/04-Multitasking/os.c
@@ -54,7 +54,7 @@ void print_str(const char *str)
  */
 unsigned int *create_task(unsigned int *stack, void (*start)(void))
 {
-	stack += STACK_SIZE - 32; /* End of stack, minus what we are about to push */
+	stack += STACK_SIZE - 17; /* End of stack, minus what we are about to push */
 	stack[8] = (unsigned int) THREAD_PSP;
 	stack[15] = (unsigned int) start;
 	stack[16] = (unsigned int) 0x01000000; /* PSR Thumb bit */

--- a/06-Preemptive/os.c
+++ b/06-Preemptive/os.c
@@ -66,7 +66,7 @@ void delay(volatile int count)
  */
 unsigned int *create_task(unsigned int *stack, void (*start)(void))
 {
-	stack += STACK_SIZE - 32; /* End of stack, minus what we are about to push */
+	stack += STACK_SIZE - 17; /* End of stack, minus what we are about to push */
 	stack[8] = (unsigned int) THREAD_PSP;
 	stack[15] = (unsigned int) start;
 	stack[16] = (unsigned int) 0x01000000; /* PSR Thumb bit */

--- a/06-Preemptive/os.c
+++ b/06-Preemptive/os.c
@@ -59,16 +59,9 @@ void delay(volatile int count)
 #define THREAD_MSP	0xFFFFFFF9
 #define THREAD_PSP	0xFFFFFFFD
 
-/* Initialize user task stack and execute it one time */
-
-/* XXX: Implementation of task creation is a little bit tricky.
- * We called `activate()` which is returning from exception.
- * At initial stage, we call `task_init()` to change from the
- * kernel mode into user mode, then switch to exception mode.
- * Thus, we can use the same way to initial the task. Don't have
- * to specially handle the first task. After initializing the
- * enviroment, we should set `THREAD_PSP` to `lr` to ensure that
- * exception return works correctly.
+/* Initialize user task stack and execute it one time.
+ * We set `THREAD_PSP` to `lr` to ensure that exception
+ * return works correctly.
  * http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/Babefdjc.html
  */
 unsigned int *create_task(unsigned int *stack, void (*start)(void))

--- a/07-Threads/threads.c
+++ b/07-Threads/threads.c
@@ -88,7 +88,7 @@ int thread_create(void (*run)(void *), void *userdata)
 	if (stack == 0)
 		return -1;
 
-	stack += STACK_SIZE - 32; /* End of stack, minus what we are about to push */
+	stack += STACK_SIZE - 17; /* End of stack, minus what we are about to push */
 	stack[8] = (unsigned int) THREAD_PSP;
 	stack[9] = (unsigned int) userdata;
 	stack[14] = (unsigned) &thread_self_terminal;

--- a/08-CMSIS/core/src/threads.c
+++ b/08-CMSIS/core/src/threads.c
@@ -15,7 +15,6 @@ typedef struct {
 
 static tcb_t tasks[MAX_TASKS];
 static int lastTask;
-static int first = 1;
 
 /* FIXME: Without naked attribute, GCC will corrupt r7 which is used for stack
  * pointer. If so, after restoring the tasks' context, we will get wrong stack
@@ -49,23 +48,17 @@ void __attribute__((naked)) pendsv_handler()
 void thread_start()
 {
 	lastTask = 0;
-	CONTROL_Type user_ctx = {
-		.b.nPRIV = 1,
-		.b.SPSEL = 1
-	};
 
 	/* Save kernel context */
 	asm volatile("mrs ip, psr\n"
 	             "push {r4-r11, ip, lr}\n");
 
+	/* Move the task's stack pointer address into r0 */
+	asm volatile("mov r0, %0\n" : : "r" (tasks[lastTask].stack));
 	/* Load user task's context and jump to the task */
-	__set_PSP((uint32_t)tasks[lastTask].stack);
-	__set_CONTROL(user_ctx.w);
-	__ISB();
-
-	asm volatile("pop {r4-r11, lr}\n"
-	             "pop {r0}\n"
-	             "bx lr\n");
+       asm volatile("ldmia r0!, {r4-r11, lr}\n"
+                    "msr psp, r0\n"
+                    "bx lr\n");
 }
 
 int thread_create(void (*run)(void *), void *userdata)
@@ -89,17 +82,11 @@ int thread_create(void (*run)(void *), void *userdata)
 		return -1;
 
 	stack += STACK_SIZE - 32; /* End of stack, minus what we are about to push */
-	if (first) {
-		stack[8] = (unsigned int) run;
-		stack[9] = (unsigned int) userdata;
-		first = 0;
-	} else {
-		stack[8] = (unsigned int) THREAD_PSP;
-		stack[9] = (unsigned int) userdata;
-		stack[14] = (unsigned) &thread_self_terminal;
-		stack[15] = (unsigned int) run;
-		stack[16] = (unsigned int) 0x01000000; /* PSR Thumb bit */
-	}
+	stack[8] = (unsigned int) THREAD_PSP;
+	stack[9] = (unsigned int) userdata;
+	stack[14] = (unsigned) &thread_self_terminal;
+	stack[15] = (unsigned int) run;
+	stack[16] = (unsigned int) 0x01000000; /* PSR Thumb bit */
 
 	/* Construct the control block */
 	tasks[threadId].stack = stack;

--- a/08-CMSIS/core/src/threads.c
+++ b/08-CMSIS/core/src/threads.c
@@ -81,7 +81,7 @@ int thread_create(void (*run)(void *), void *userdata)
 	if (stack == 0)
 		return -1;
 
-	stack += STACK_SIZE - 32; /* End of stack, minus what we are about to push */
+	stack += STACK_SIZE - 17; /* End of stack, minus what we are about to push */
 	stack[8] = (unsigned int) THREAD_PSP;
 	stack[9] = (unsigned int) userdata;
 	stack[14] = (unsigned) &thread_self_terminal;


### PR DESCRIPTION
1. Accroding to b4c7473, it's able to use exception return
to do mode switch the first time a task was activated.

2. In the comment - "End of stack, minus what we are about to push",
The number 32 is not equal to 'what we are about to push'.
Actually, the correct number is 9 for pop psp register and
8 for exception return.
> If you want to keep value 32 to remain some safe space at the end of stack, the comment may be not appropriate.