### PR TITLE
Fix wrong processor mode in first time exception return

### DIFF
--- a/04-Multitasking/asm.h
+++ b/04-Multitasking/asm.h
@@ -2,6 +2,7 @@
 #define __ASM_H_
 
 unsigned int *activate(unsigned int *stack);
+void task_init_env(unsigned int *stack);
 void syscall(void);
 
 #endif

--- a/04-Multitasking/context_switch.S
+++ b/04-Multitasking/context_switch.S
@@ -1,5 +1,10 @@
 .syntax unified
 
+.macro save_kernel_state
+	mrs ip, psr
+	push {r4, r5, r6, r7, r8, r9, r10, r11, ip, lr}
+.endm
+
 .type svc_handler, %function
 .global svc_handler
 svc_handler:
@@ -15,13 +20,23 @@ svc_handler:
 
 .global activate
 activate:
-	/* save kernel state */
-	mrs ip, psr
-	push {r4, r5, r6, r7, r8, r9, r10, r11, ip, lr}
+	save_kernel_state
 
 	/* load user state */
 	ldmia r0!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}
 	msr psp, r0
 
 	/* jump to user task */
+	bx lr
+
+.global task_init_env
+task_init_env:
+	save_kernel_state
+
+	/* switch to process stack */
+	msr psp, r0
+	mov r0, #3
+	msr control, r0
+	isb
+	bl syscall
 	bx lr

--- a/04-Multitasking/os.c
+++ b/04-Multitasking/os.c
@@ -63,6 +63,15 @@ unsigned int *create_task(unsigned int *stack, void (*start)(void))
 	return stack;
 }
 
+/* After reset, processor is at thread and privileged mode.
+ * Switch to handler mode to ensure an appropriate exception return.
+ */
+void task_init(void)
+{
+	unsigned int empty[32];
+	task_init_env(empty + 32);
+}
+
 void task1_func(void)
 {
 	print_str("task1: Created!\n");
@@ -95,6 +104,7 @@ int main(void)
 	size_t current_task;
 
 	usart_init();
+	task_init();
 
 	print_str("OS: Starting...\n");
 	print_str("OS: First create task 1\n");

--- a/08-CMSIS/core/src/threads.c
+++ b/08-CMSIS/core/src/threads.c
@@ -22,7 +22,7 @@ static int lastTask;
  */
 void __attribute__((naked)) pendsv_handler()
 {
-	/* Save the old task's context */
+	/* Save the old task's context[1] */
 	asm volatile("mrs   r0, psp\n"
 	             "stmdb r0!, {r4-r11, lr}\n");
 	/* To save the last task's sp from r0 into its tcb*/
@@ -45,20 +45,72 @@ void __attribute__((naked)) pendsv_handler()
 }
 
 
-void thread_start()
+/* As PendSV does, this function also switches context and
+ * maintain assembly on its own. This avoids the compiler
+ * modifying register at prologue/epilogue sequences and
+ * corrupts inline-assembly usage.
+ */
+void __attribute__((naked)) thread_start()
 {
 	lastTask = 0;
+	CONTROL_Type user_ctx = {
+		.b.nPRIV = 1,
+		.b.SPSEL = 1
+	};
 
-	/* Save kernel context */
-	asm volatile("mrs ip, psr\n"
-	             "push {r4-r11, ip, lr}\n");
-
-	/* Move the task's stack pointer address into r0 */
-	asm volatile("mov r0, %0\n" : : "r" (tasks[lastTask].stack));
+	/* Reset APSR before context switch
+	 * Make sure we have a _clean_ PSR for the task.
+	 */
+	asm volatile("mov r0, #0\n"
+	             "msr APSR_nzcvq, r0\n");
 	/* Load user task's context and jump to the task */
-       asm volatile("ldmia r0!, {r4-r11, lr}\n"
-                    "msr psp, r0\n"
-                    "bx lr\n");
+	__set_PSP((uint32_t) tasks[lastTask].stack);
+	__set_CONTROL(user_ctx.w);
+	__ISB();
+
+	/* This is how we simulate stack handling that pendsv_handler
+	 * does. Thread_create sets 17 entries in stack, and the 9
+	 * entries we pop here will be pushed back in pendsv_handler
+	 * in the same order.
+	 *
+	 *
+	 *                      pop {r4-r11, lr}
+	 *                      ldr r0, [sp]
+	 *          stack
+	 *  offset -------
+	 *        |   16  | <- Reset value of PSR
+	 *         -------
+	 *        |   15  | <- Task entry
+	 *         -------
+	 *        |   14  | <- LR for task
+	 *         -------
+	 *        |  ...  |                             register
+	 *         -------                              -------
+	 *        |   9   | <- Task argument ---->     |   r0  |
+	 * psp after pop--<                             -------
+	 *        |   8   | <- EXC_RETURN    ---->     |   lr  |
+	 *         -------                              -------
+	 *        |   7   |                            |  r11  |
+	 *         -------                              -------
+	 *        |  ...  |                            |  ...  |
+	 *         -------                              -------
+	 *        |   0   |                            |   r4  |
+	 * psp ->  -------                              -------
+	 *
+	 * Instead of "pop {r0}", use "ldr r0, [sp]" to ensure consistent
+	 * with the way how PendSV saves _old_ context[1].
+	 */
+	asm volatile("pop {r4-r11, lr}\n"
+	             "ldr r0, [sp]\n");
+	/* Okay, we are ready to run first task, get address from
+	 * stack[15]. We just pop 10 register so #24 comes from
+	 * (15 - 9) * sizeof(entry of sp) = 6 * 4.
+	 */
+	asm volatile("ldr pc, [sp, #24]\n");
+
+	/* Never reach here */
+	while(1);
+
 }
 
 int thread_create(void (*run)(void *), void *userdata)
@@ -115,3 +167,14 @@ void thread_self_terminal()
 	/* And now wait for death to kick in */
 	while (1);
 }
+
+/* [1] Exception entry only saves R0-R4, R12, LR, PC and xPSR,
+ *     which means PendSV has to save other context (R4-R11) itself to
+ *     complete context switch.
+ *     Also, pushing LR (=EXC_RETURN) into thread stack before switching
+ *     task is needed in order to perform exception return next time the task
+ *     is selected to run.
+ *     Reference:
+ *         Cortex-M4 Devices: Generic User Guide (ARM DUI 0553A):
+ *         2.3.7 Exception entry and return
+ */


### PR DESCRIPTION
Close #27 , fix 04, 07 and 08 which run first thread in wrong mode. See the comments in each commit in detail. 
Close #23 , add `naked` attribute before `thread_start`

