### PR TITLE
Fix broken QEMU STM32 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Build a minimal multi-tasking OS kernel for ARM from scratch
 
 Prerequisites
 -------------
-- [QEMU with an STM32 microcontroller implementation](http://beckus.github.io/qemu_stm32/)
+- [QEMU with an STM32 microcontroller implementation](https://github.com/beckus/qemu_stm32)
   - Build instructions
 ```
 ./configure --disable-werror --enable-debug \


### PR DESCRIPTION
The link to `http://beckus.github.io/qemu_stm32/` currently redirects to an expired domain (`abeckus.com`).

This patch updates the reference to point directly to the GitHub repository (`https://github.com/beckus/qemu_stm32`) to ensure accessibility.